### PR TITLE
Refactor button icons

### DIFF
--- a/packages/button/src/styles.tsx
+++ b/packages/button/src/styles.tsx
@@ -1,22 +1,11 @@
 import * as tinycolor from 'tinycolor2'
-import styled, {DefaultTheme} from 'styled-components'
+import {DefaultTheme} from 'styled-components'
 import {getLinearGradientWithStates} from './helpers'
-import {ButtonIconPosition} from './types'
-
-export type IntentType = 'success' | 'warning' | 'info' | 'danger' | 'none'
-
-export type AppearanceType =
-  | 'flat'
-  | 'primary'
-  | 'minimal'
-  | 'default'
-  | 'subtle'
-
-export const SvgWrapper = styled.div``
+import {ButtonIntentType, ButtonAppearanceType} from './types'
 
 export const getButtonTextColor = (
-  intent: IntentType = 'none',
-  appearance?: AppearanceType,
+  intent: ButtonIntentType = 'none',
+  appearance?: ButtonAppearanceType,
   disabled?: boolean
 ) => (_: {theme: DefaultTheme}) => {
   const {scales, colors} = _.theme
@@ -39,8 +28,8 @@ export const getButtonTextColor = (
 }
 
 export const getButtonStyle = (
-  appearance?: AppearanceType,
-  intent: IntentType = 'none'
+  appearance?: ButtonAppearanceType,
+  intent: ButtonIntentType = 'none'
 ) => (_: {theme: DefaultTheme}) => {
   const {scales, colors} = _.theme
   const disabled = {
@@ -161,17 +150,5 @@ export const getButtonStyle = (
         },
         ':disabled': disabled
       }
-  }
-}
-
-export function getIconAttachmentStyle(iconPosition?: ButtonIconPosition) {
-  return {
-    justifyContent:
-      iconPosition === 'center'
-        ? 'center'
-        : iconPosition === 'left'
-        ? 'space-between'
-        : 'space-between',
-    'flex-direction': iconPosition === 'left' ? 'row-reverse' : 'row'
   }
 }

--- a/packages/button/src/types.ts
+++ b/packages/button/src/types.ts
@@ -14,8 +14,6 @@ export type ButtonAppearanceType =
   | 'default'
   | 'subtle'
 
-export type ButtonIconPosition = 'left' | 'center' | 'right'
-
 export interface ButtonLikeProps {
   intent?: ButtonIntentType
   appearance?: ButtonAppearanceType
@@ -35,8 +33,8 @@ export interface ButtonProps extends ButtonLikeProps {
   onClick?: React.MouseEventHandler<HTMLButtonElement>
   isLoading?: boolean
   borderRadius?: number
-  icon?: React.ComponentType
-  iconPosition?: ButtonIconPosition
+  iconAfter?: React.ElementType
+  iconBefore?: React.ElementType
 }
 
 export type StyledTextProps = ButtonProps &
@@ -45,6 +43,5 @@ export type StyledTextProps = ButtonProps &
 export type StyledSpinnerProps = {
   marginRight?: number
   marginLeft?: number
-  iconPosition?: 'left' | 'center'
   height: number
 }

--- a/stories/button.stories.js
+++ b/stories/button.stories.js
@@ -44,42 +44,38 @@ storiesOf('Core|Button', module)
   .add('appearance:default-with-icon', () => (
     <React.Fragment>
       <p>
-        <Button
-          icon={ArrowRightRegular}
-          iconPosition="center"
-          intent="info"
-        ></Button>
+        <Button iconAfter={ArrowRightRegular} intent="info"></Button>
       </p>
       <p>
-        <Button icon={ArrowRightRegular} iconPosition="left" disabled>
+        <Button iconBefore={ArrowRightRegular} disabled>
           Hulk smash!
         </Button>
       </p>
       <p>
-        <Button icon={ArrowRightRegular}>Hulk smash!</Button>
+        <Button iconAfter={ArrowRightRegular}>Hulk smash!</Button>
       </p>
       <p>
-        <Button icon={ArrowRightRegular} intent="info">
+        <Button iconAfter={ArrowRightRegular} intent="info">
           Hulk smash!
         </Button>
       </p>
       <p>
-        <Button icon={ArrowRightRegular} intent="success">
+        <Button iconAfter={ArrowRightRegular} intent="success">
           Hulk smash!
         </Button>
       </p>
       <p>
-        <Button icon={ArrowRightRegular} intent="warning">
+        <Button iconAfter={ArrowRightRegular} intent="warning">
           Hulk smash!
         </Button>
       </p>
       <p>
-        <Button icon={CalendarRegular} intent="danger">
+        <Button iconAfter={CalendarRegular} intent="danger">
           Hulk smash!
         </Button>
       </p>
       <p>
-        <Button icon={ArrowRightRegular}>Hulk smash!</Button>
+        <Button iconAfter={ArrowRightRegular}>Hulk smash!</Button>
       </p>
     </React.Fragment>
   ))
@@ -118,32 +114,48 @@ storiesOf('Core|Button', module)
   .add('appearance:primary-with-icon', () => (
     <React.Fragment>
       <p>
-        <Button icon={ArrowRightRegular} appearance="primary" disabled>
+        <Button iconAfter={ArrowRightRegular} appearance="primary" disabled>
           Hulk smash!
         </Button>
       </p>
       <p>
-        <Button icon={ArrowRightRegular} appearance="primary">
+        <Button iconAfter={ArrowRightRegular} appearance="primary">
           Hulk smash!
         </Button>
       </p>
       <p>
-        <Button icon={ArrowRightRegular} appearance="primary" intent="info">
+        <Button
+          iconAfter={ArrowRightRegular}
+          appearance="primary"
+          intent="info"
+        >
           Hulk smash!
         </Button>
       </p>
       <p>
-        <Button icon={ArrowRightRegular} appearance="primary" intent="success">
+        <Button
+          iconAfter={ArrowRightRegular}
+          appearance="primary"
+          intent="success"
+        >
           Hulk smash!
         </Button>
       </p>
       <p>
-        <Button icon={ArrowRightRegular} appearance="primary" intent="warning">
+        <Button
+          iconAfter={ArrowRightRegular}
+          appearance="primary"
+          intent="warning"
+        >
           Hulk smash!
         </Button>
       </p>
       <p>
-        <Button icon={ArrowRightRegular} appearance="primary" intent="danger">
+        <Button
+          iconAfter={ArrowRightRegular}
+          appearance="primary"
+          intent="danger"
+        >
           Hulk smash!
         </Button>
       </p>
@@ -184,32 +196,48 @@ storiesOf('Core|Button', module)
   .add('appearance:minimal-with-icon', () => (
     <React.Fragment>
       <p>
-        <Button icon={ArrowRightRegular} appearance="minimal" disabled>
+        <Button iconAfter={ArrowRightRegular} appearance="minimal" disabled>
           Hulk smash!
         </Button>
       </p>
       <p>
-        <Button icon={ArrowRightRegular} appearance="minimal">
+        <Button iconAfter={ArrowRightRegular} appearance="minimal">
           Hulk smash!
         </Button>
       </p>
       <p>
-        <Button icon={ArrowRightRegular} appearance="minimal" intent="info">
+        <Button
+          iconAfter={ArrowRightRegular}
+          appearance="minimal"
+          intent="info"
+        >
           Hulk smash!
         </Button>
       </p>
       <p>
-        <Button icon={ArrowRightRegular} appearance="minimal" intent="success">
+        <Button
+          iconAfter={ArrowRightRegular}
+          appearance="minimal"
+          intent="success"
+        >
           Hulk smash!
         </Button>
       </p>
       <p>
-        <Button icon={ArrowRightRegular} appearance="minimal" intent="warning">
+        <Button
+          iconAfter={ArrowRightRegular}
+          appearance="minimal"
+          intent="warning"
+        >
           Hulk smash!
         </Button>
       </p>
       <p>
-        <Button icon={ArrowRightRegular} appearance="minimal" intent="danger">
+        <Button
+          iconAfter={ArrowRightRegular}
+          appearance="minimal"
+          intent="danger"
+        >
           Hulk smash!
         </Button>
       </p>
@@ -255,32 +283,40 @@ storiesOf('Core|Button', module)
   .add('appearance:flat-with-icon', () => (
     <React.Fragment>
       <p>
-        <Button icon={ArrowRightRegular} appearance="flat" disabled>
+        <Button iconAfter={ArrowRightRegular} appearance="flat" disabled>
           Hulk smash!
         </Button>
       </p>
       <p>
-        <Button icon={ArrowRightRegular} appearance="flat">
+        <Button iconAfter={ArrowRightRegular} appearance="flat">
           Hulk smash!
         </Button>
       </p>
       <p>
-        <Button icon={ArrowRightRegular} appearance="flat" intent="info">
+        <Button iconAfter={ArrowRightRegular} appearance="flat" intent="info">
           Hulk smash!
         </Button>
       </p>
       <p>
-        <Button icon={ArrowRightRegular} appearance="flat" intent="success">
+        <Button
+          iconAfter={ArrowRightRegular}
+          appearance="flat"
+          intent="success"
+        >
           Hulk smash!
         </Button>
       </p>
       <p>
-        <Button icon={ArrowRightRegular} appearance="flat" intent="warning">
+        <Button
+          iconAfter={ArrowRightRegular}
+          appearance="flat"
+          intent="warning"
+        >
           Hulk smash!
         </Button>
       </p>
       <p>
-        <Button icon={ArrowRightRegular} appearance="flat" intent="danger">
+        <Button iconAfter={ArrowRightRegular} appearance="flat" intent="danger">
           Hulk smash!
         </Button>
       </p>
@@ -293,7 +329,7 @@ storiesOf('Core|Button', module)
   ))
   .add('borderRadius:30-with-icon', () => (
     <Button
-      icon={ArrowRightRegular}
+      iconAfter={ArrowRightRegular}
       appearance="flat"
       intent="success"
       borderRadius={30}
@@ -336,32 +372,44 @@ storiesOf('Core|Button', module)
   .add('appearance:subtle-with-icon', () => (
     <React.Fragment>
       <p>
-        <Button icon={ArrowRightRegular} appearance="subtle" disabled>
+        <Button iconAfter={ArrowRightRegular} appearance="subtle" disabled>
           Hulk smash!
         </Button>
       </p>
       <p>
-        <Button icon={ArrowRightRegular} appearance="subtle">
+        <Button iconAfter={ArrowRightRegular} appearance="subtle">
           Hulk smash!
         </Button>
       </p>
       <p>
-        <Button icon={ArrowRightRegular} appearance="subtle" intent="info">
+        <Button iconAfter={ArrowRightRegular} appearance="subtle" intent="info">
           Hulk smash!
         </Button>
       </p>
       <p>
-        <Button icon={ArrowRightRegular} appearance="subtle" intent="success">
+        <Button
+          iconAfter={ArrowRightRegular}
+          appearance="subtle"
+          intent="success"
+        >
           Hulk smash!
         </Button>
       </p>
       <p>
-        <Button icon={ArrowRightRegular} appearance="subtle" intent="warning">
+        <Button
+          iconAfter={ArrowRightRegular}
+          appearance="subtle"
+          intent="warning"
+        >
           Hulk smash!
         </Button>
       </p>
       <p>
-        <Button icon={ArrowRightRegular} appearance="subtle" intent="danger">
+        <Button
+          iconAfter={ArrowRightRegular}
+          appearance="subtle"
+          intent="danger"
+        >
           Hulk smash!
         </Button>
       </p>
@@ -386,75 +434,76 @@ storiesOf('Core|Button', module)
   .add('height-with-icon', () => (
     <React.Fragment>
       <p>
-        <Button icon={ArrowRightRegular} height={24}>
+        <Button iconAfter={ArrowRightRegular} height={24}>
           Hulk smash!
         </Button>
       </p>
       <p>
-        <Button icon={ArrowRightRegular} height={32}>
+        <Button iconAfter={ArrowRightRegular} height={32}>
           Hulk smash!
         </Button>
       </p>
       <p>
-        <Button icon={ArrowRightRegular} height={40}>
+        <Button iconAfter={ArrowRightRegular} height={40}>
           Hulk smash!
         </Button>
       </p>
       <p>
-        <Button icon={ArrowRightRegular} height={48}>
+        <Button iconAfter={ArrowRightRegular} height={48}>
           Hulk smash!
         </Button>
       </p>
     </React.Fragment>
   ))
-  .add('loading', () => <Button isLoading>Hulk smash!</Button>)
-  .add('full', () => (
-    <Button isLoading full>
-      Hulk smash!
-    </Button>
-  ))
-  .add('full-with-icon', () => (
+  .add('loading', () => (
     <React.Fragment>
       <p>
-        <Button
-          full
-          icon={ArrowRightRegular}
-          iconPosition="center"
-          intent="info"
-        ></Button>
+        <Button isLoading>Hello</Button>
       </p>
+    </React.Fragment>
+  ))
+  .add('full', () => (
+    <React.Fragment>
       <p>
-        <Button full icon={ArrowRightRegular} iconPosition="left" disabled>
+        <Button full intent="info">
           Hulk smash!
         </Button>
       </p>
       <p>
-        <Button full icon={ArrowRightRegular}>
+        <Button full iconBefore={ArrowRightRegular} intent="info"></Button>
+      </p>
+      <p>
+        <Button full iconBefore={ArrowRightRegular} disabled>
           Hulk smash!
         </Button>
       </p>
       <p>
-        <Button full icon={ArrowRightRegular} intent="info">
+        <Button full iconAfter={ArrowRightRegular}>
           Hulk smash!
         </Button>
       </p>
       <p>
-        <Button full icon={ArrowRightRegular} intent="success">
+        <Button full iconAfter={ArrowRightRegular} intent="info">
           Hulk smash!
         </Button>
       </p>
       <p>
-        <Button full icon={ArrowRightRegular} intent="warning">
+        <Button full iconAfter={ArrowRightRegular} intent="success">
           Hulk smash!
         </Button>
       </p>
       <p>
-        <Button full icon={CalendarRegular} intent="danger">
+        <Button full iconAfter={ArrowRightRegular} intent="warning">
           Hulk smash!
         </Button>
       </p>
       <p>
-        <Button full icon={ArrowRightRegular}>
+        <Button full iconAfter={CalendarRegular} intent="danger">
+          Hulk smash!
+        </Button>
+      </p>
+      <p>
+        <Button full iconAfter={ArrowRightRegular}>
           Hulk smash!
         </Button>
       </p>


### PR DESCRIPTION
Switched from `icon={ReactComponent} iconPosition="left"` to `iconAfter={ReactComponent}` and `iconBefore={ReactComponent}`. Center position is handled automatically.

New API:

```tsx
<Button iconAfter={ChevronDown} iconBefore={Cog} />
```