### PR TITLE
Fix broken focus on label click in TextInput

### DIFF
--- a/packages/text-input/src/index.tsx
+++ b/packages/text-input/src/index.tsx
@@ -10,6 +10,7 @@ import {TextInputAffix} from './components/affix'
 
 const TextInput: React.FC<TextInputProps> = ({
   children,
+  className,
   innerRef,
   affixBefore,
   affixAfter,
@@ -30,6 +31,7 @@ const TextInput: React.FC<TextInputProps> = ({
       width={defaults.width}
       full={defaults.full}
       ref={innerRef}
+      className={className}
     >
       {affixBefore && (
         <TextInputAffix

--- a/packages/text-input/src/index.tsx
+++ b/packages/text-input/src/index.tsx
@@ -18,6 +18,7 @@ const TextInput: React.FC<TextInputProps> = ({
   ...props
 }) => {
   const defaults = useDefaults('textInput', props, {
+    width: undefined,
     height: 32,
     full: false,
     appearance: 'default' as TextInputAppearanceType
@@ -25,7 +26,11 @@ const TextInput: React.FC<TextInputProps> = ({
   const inputRef = React.useRef<HTMLInputElement>(null)
 
   return (
-    <S.TextInputContainer ref={innerRef} {...defaults}>
+    <S.TextInputContainer
+      width={defaults.width}
+      full={defaults.full}
+      ref={innerRef}
+    >
       {affixBefore && (
         <TextInputAffix
           isBefore

--- a/packages/text-input/src/styled.tsx
+++ b/packages/text-input/src/styled.tsx
@@ -7,11 +7,12 @@ import {getValueWithUnit} from '@smashing/theme'
 type InputProps = TextInputProps &
   Required<Pick<TextInputProps, 'height' | 'appearance' | 'full'>>
 
-export const TextInputContainer = styled.div<
-  {
-    height: number | string
-  } & InputProps
->`
+type TextInputContainerProps = {
+  full?: boolean
+  width?: number | string
+}
+
+export const TextInputContainer = styled.div<TextInputContainerProps>`
   position: relative;
   ${_ => ({
     width: _.width ? getValueWithUnit(_.width) : _.full ? '100%' : 'fit-content'


### PR DESCRIPTION
All props were passed to both container and input including id. Label `for` attribute won't work if there're more than 2 elements with the same id.