### PR TITLE
Add gridArea property to FormField

### DIFF
--- a/packages/form-field/src/index.tsx
+++ b/packages/form-field/src/index.tsx
@@ -18,6 +18,7 @@ export const FormField: React.FC<FormFieldProps> = ({
   id,
   label,
   name,
+  gridArea,
   className,
   ...props
 }) => {
@@ -43,6 +44,7 @@ export const FormField: React.FC<FormFieldProps> = ({
       labelAppearance={labelAppearance}
       labelColumnWidth={labelColumnWidth}
       className={className}
+      gridArea={gridArea || name}
     >
       {hasLabel && (
         <styled.Label

--- a/packages/form-field/src/styles.tsx
+++ b/packages/form-field/src/styles.tsx
@@ -62,6 +62,7 @@ export const Alert = styled(PureAlert)<AlertProps>`
 `
 
 interface FormFieldProps {
+  gridArea?: string
   labelColumnWidth: string
   labelAppearance: FormFieldLabelAppearance
 }
@@ -72,6 +73,9 @@ export const DefaultInput = styled.input``
 export const FormField = styled.div<FormFieldProps>`
   position: relative;
   display: grid;
+  ${_ => ({
+    gridArea: _.gridArea
+  })}
 
   ${_ =>
     _.labelAppearance === 'inline' &&

--- a/packages/form-field/src/types.ts
+++ b/packages/form-field/src/types.ts
@@ -41,5 +41,9 @@ export type FormFieldProps = FieldProps & {
    * An optional hint under the input element.
    */
   hint?: string | React.ReactNode
+  /**
+   * CSS grid-area property applied to field container. By default name will used.
+   */
+  gridArea?: string
   className?: string
 }


### PR DESCRIPTION
```tsx
const Form = styled.form`
  grid-template-areas: 'firstCell firstCell secondCell';
`

<Form>
  <FormField gridArea="firstCell" /> 
  <FormField gridArea="secondCell" />
</Form>
```

First field will take 2/3 of row width. Second will take 1/3.
