### PR TITLE
Tweak calendar input icons and colors

### DIFF
--- a/packages/calendar-input/src/date-input.tsx
+++ b/packages/calendar-input/src/date-input.tsx
@@ -7,7 +7,6 @@ import {
   DateValue,
   KEYS
 } from './utils'
-import {CalendarIcon} from './icons'
 import {DateInputProps} from './types'
 
 export const DateInput: React.FC<DateInputProps> = ({

--- a/packages/calendar-input/src/date-input.tsx
+++ b/packages/calendar-input/src/date-input.tsx
@@ -7,7 +7,7 @@ import {
   DateValue,
   KEYS
 } from './utils'
-import {CalendarIcon, ChevronUpIcon} from './icons'
+import {CalendarIcon} from './icons'
 import {DateInputProps} from './types'
 
 export const DateInput: React.FC<DateInputProps> = ({
@@ -20,8 +20,7 @@ export const DateInput: React.FC<DateInputProps> = ({
   minutesInterval,
   timeValue,
   isExpanded,
-  expandIcon = () => <CalendarIcon />,
-  collapseIcon = () => <ChevronUpIcon />,
+  iconAfter,
   ...props
 }) => {
   const CalendarDate = hasTime
@@ -273,12 +272,21 @@ export const DateInput: React.FC<DateInputProps> = ({
       }}
       aria-expanded={isExpanded}
       onPaste={handlePaste}
+      height={props.height}
       width={props.width}
       onClick={handleClick}
       appearance={props.appearance}
       onKeyDown={handleKeyDown}
       value={CalendarDate.getStringValueForParts(inputValue)}
-      affixAfter={isExpanded ? collapseIcon : expandIcon}
+      affixAfter={
+        typeof iconAfter === 'function'
+          ? () =>
+              iconAfter({
+                toggle: handleClick,
+                isShown: isExpanded as boolean
+              })
+          : iconAfter
+      }
       onClickAfter={() => handleClick()}
     ></S.StyledInput>
   )

--- a/packages/calendar-input/src/icons.tsx
+++ b/packages/calendar-input/src/icons.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import styled from 'styled-components'
 
 export const ClockIcon = () => (
   <svg
@@ -60,91 +61,48 @@ export const ClockIcon = () => (
 
 export const ChevronUpIcon = () => (
   <svg
-    width="16"
-    height="10"
-    viewBox="0 0 16 10"
-    fill="none"
     xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
   >
-    <path
-      fillRule="evenodd"
-      clipRule="evenodd"
-      d="M15.6891 9.19117C15.2745 9.60294 14.6023 9.60294 14.1877 9.19117L8 3.04558L1.81233 9.19117C1.39773 9.60294 0.725541 9.60294 0.310946 9.19117C-0.103649 8.77939 -0.103649 8.11177 0.310947 7.7L7.24931 0.808829C7.44841 0.611088 7.71844 0.499999 8 0.499999C8.28156 0.499999 8.5516 0.611088 8.75069 0.80883L15.6891 7.7C16.1036 8.11177 16.1036 8.77939 15.6891 9.19117Z"
-      fill="currentColor"
-    />
+    <g fill="currentColor">
+      <path d="M17 13.41l-4.29-4.24a1 1 0 0 0-1.42 0l-4.24 4.24a1 1 0 0 0 0 1.42 1 1 0 0 0 1.41 0L12 11.29l3.54 3.54a1 1 0 0 0 .7.29 1 1 0 0 0 .71-.29 1 1 0 0 0 .05-1.42z"></path>
+    </g>
   </svg>
 )
 
-export const ChevronDownIconSm = () => (
+export const ChevronDownIcon = () => (
   <svg
-    width="16"
-    height="16"
-    viewBox="0 0 16 16"
-    fill="none"
     xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
   >
-    <path
-      fillRule="evenodd"
-      clipRule="evenodd"
-      d="M4.29289 5.29289C4.68342 4.90237 5.31658 4.90237 5.70711 5.29289L8 7.58579L10.2929 5.29289C10.6834 4.90237 11.3166 4.90237 11.7071 5.29289C12.0976 5.68342 12.0976 6.31658 11.7071 6.70711L8.70711 9.70711C8.51957 9.89464 8.26522 10 8 10C7.73478 10 7.48043 9.89464 7.29289 9.70711L4.29289 6.70711C3.90237 6.31658 3.90237 5.68342 4.29289 5.29289Z"
-      fill="currentColor"
-    />
+    <g fill="currentColor">
+      <path d="M17 9.17a1 1 0 0 0-1.41 0L12 12.71 8.46 9.17a1 1 0 0 0-1.41 0 1 1 0 0 0 0 1.42l4.24 4.24a1 1 0 0 0 1.42 0L17 10.59a1 1 0 0 0 0-1.42z"></path>
+    </g>
   </svg>
 )
 
-export const CalendarIcon = () => (
+const CalendarIconFC: React.FC<{isShown: boolean}> = ({isShown, ...props}) => (
   <svg
-    width="16"
-    height="16"
-    viewBox="0 0 16 16"
-    fill="none"
     xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    {...props}
   >
-    <path
-      fillRule="evenodd"
-      clipRule="evenodd"
-      d="M3 4C2.44772 4 2 4.44772 2 5V13C2 13.5523 2.44772 14 3 14H13C13.5523 14 14 13.5523 14 13V5C14 4.44772 13.5523 4 13 4V2C14.6569 2 16 3.34315 16 5V13C16 14.6569 14.6569 16 13 16H3C1.34315 16 0 14.6569 0 13V5C0 3.34315 1.34315 2 3 2V4Z"
-      fill="currentColor"
-    />
-    <path
-      d="M5 1C5 0.447715 5.44772 0 6 0C6.55228 0 7 0.447715 7 1V3C7 3.55228 6.55228 4 6 4C5.44772 4 5 3.55228 5 3V1Z"
-      fill="currentColor"
-    />
-    <path
-      d="M9 1C9 0.447715 9.44772 0 10 0C10.5523 0 11 0.447715 11 1V3C11 3.55228 10.5523 4 10 4C9.44772 4 9 3.55228 9 3V1Z"
-      fill="currentColor"
-    />
-    <path
-      d="M14 3C14 3.55228 13.5523 4 13 4C12.4477 4 12 3.55228 12 3C12 2.44772 12.4477 2 13 2C13.5523 2 14 2.44772 14 3Z"
-      fill="currentColor"
-    />
-    <path
-      d="M4 3C4 3.55228 3.55228 4 3 4C2.44772 4 2 3.55228 2 3C2 2.44772 2.44772 2 3 2C3.55228 2 4 2.44772 4 3Z"
-      fill="currentColor"
-    />
-    <path
-      d="M6 7C6 7.55228 5.55228 8 5 8C4.44772 8 4 7.55228 4 7C4 6.44772 4.44772 6 5 6C5.55228 6 6 6.44772 6 7Z"
-      fill="currentColor"
-    />
-    <path
-      d="M6 11C6 11.5523 5.55228 12 5 12C4.44772 12 4 11.5523 4 11C4 10.4477 4.44772 10 5 10C5.55228 10 6 10.4477 6 11Z"
-      fill="currentColor"
-    />
-    <path
-      d="M9 11C9 11.5523 8.55228 12 8 12C7.44772 12 7 11.5523 7 11C7 10.4477 7.44772 10 8 10C8.55228 10 9 10.4477 9 11Z"
-      fill="currentColor"
-    />
-    <path
-      d="M9 7C9 7.55228 8.55228 8 8 8C7.44772 8 7 7.55228 7 7C7 6.44772 7.44772 6 8 6C8.55228 6 9 6.44772 9 7Z"
-      fill="currentColor"
-    />
-    <path
-      d="M12 7C12 7.55228 11.5523 8 11 8C10.4477 8 10 7.55228 10 7C10 6.44772 10.4477 6 11 6C11.5523 6 12 6.44772 12 7Z"
-      fill="currentColor"
-    />
-    <path
-      d="M12 11C12 11.5523 11.5523 12 11 12C10.4477 12 10 11.5523 10 11C10 10.4477 10.4477 10 11 10C11.5523 10 12 10.4477 12 11Z"
-      fill="currentColor"
-    />
+    <g fill="currentColor">
+      <path d="M3 22h18a1 1 0 0 0 1-1V5a1 1 0 0 0-1-1h-4V2h-2v2H9V2H7v2H3a1 1 0 0 0-1 1v16a1 1 0 0 0 1 1zM4 6h3v1h2V6h6v1h2V6h3v2H4V6zm0 4h16v10H4V10z"></path>
+      <path d="M7 12h2v2H7zm0 4h2v2H7zm4-4h2v2h-2zm0 4h2v2h-2zm4-4h2v2h-2zm0 4h2v2h-2z"></path>
+    </g>
   </svg>
 )
+
+export const CalendarIcon = styled(CalendarIconFC)`
+  ${_ =>
+    _.isShown && {
+      color: _.theme.colors.icon.selected
+    }}
+`

--- a/packages/calendar-input/src/index.tsx
+++ b/packages/calendar-input/src/index.tsx
@@ -3,11 +3,11 @@ import getUserLocale from 'get-user-locale'
 import {useDefaults} from '@smashing/theme'
 import {TextInputAppearanceType} from '@smashing/text-input'
 import {PopoverProps} from '@smashing/popover'
-import {CalendarInputProps, CalendarInputAppearanceType} from './types'
+import {CalendarInputProps, CalendarPopoverAppearanceType} from './types'
 import * as S from './styles'
 import {DateInput} from './date-input'
 import {TimePicker} from './time-picker'
-import {ClockIcon} from './icons'
+import {ClockIcon, CalendarIcon} from './icons'
 
 const CalendarInput: React.FC<CalendarInputProps> = ({
   onChange = () => {},
@@ -16,8 +16,6 @@ const CalendarInput: React.FC<CalendarInputProps> = ({
   clockIcon = <ClockIcon />,
   nextIcon,
   prevIcon,
-  collapseIcon,
-  expandIcon,
   ...props
 }) => {
   const [timeIsOpen, setTimeIsOpen] = React.useState(false)
@@ -35,13 +33,15 @@ const CalendarInput: React.FC<CalendarInputProps> = ({
     hours: undefined
   })
 
-  const defaults = useDefaults('calendar', props, {
-    popoverAppearance: 'default' as CalendarInputAppearanceType,
+  const defaults = useDefaults('calendarInput', props, {
+    popoverAppearance: 'default' as CalendarPopoverAppearanceType,
     inputAppearance: 'default' as TextInputAppearanceType,
+    height: 32,
     width: 200,
     hoursLabel: 'Hours',
     minutesLabel: 'Min',
-    minutesInterval: 5
+    minutesInterval: 5,
+    iconAfter: ({isShown}) => <CalendarIcon isShown={isShown} />
   })
 
   React.useEffect(() => {
@@ -69,12 +69,12 @@ const CalendarInput: React.FC<CalendarInputProps> = ({
   }
 
   const popoverPropsForAppearance = {
-    outline: {
+    dropdown: {
       transitionType: 'expand',
       targetOffset: -1
     } as Partial<PopoverProps>,
-    default: {}
-  }[defaults.popoverAppearance || 'default']
+    card: {}
+  }[defaults.popoverAppearance || 'card']
 
   const changeTimeValue = (hours?: number, minutes?: number) => {
     setTimeValue({minutes, hours})
@@ -129,7 +129,6 @@ const CalendarInput: React.FC<CalendarInputProps> = ({
               header={timeHeader}
               close={() => setTimeIsOpen(false)}
               clockIcon={clockIcon}
-              collapseIcon={collapseIcon}
               changeTime={changeTimeValue}
               minuteValue={value ? value.getMinutes() : timeValue.minutes}
               hourValue={value ? value.getHours() : timeValue.hours}
@@ -150,12 +149,12 @@ const CalendarInput: React.FC<CalendarInputProps> = ({
           onChange={onChange}
           value={value}
           hasTime={hasTime}
+          height={defaults.height}
           width={defaults.width}
           minutesInterval={minutesInterval}
           appearance={defaults.inputAppearance}
           timeValue={timeValue}
-          expandIcon={expandIcon}
-          collapseIcon={collapseIcon}
+          iconAfter={defaults.iconAfter}
         />
       )}
     </S.StyledContainer>
@@ -165,5 +164,18 @@ const CalendarInput: React.FC<CalendarInputProps> = ({
 export {CalendarInput, CalendarInputProps}
 
 declare module 'styled-components' {
-  export interface SmashingCalendarDefaults extends Partial<{}> {}
+  export interface SmashingCalendarInputDefaults
+    extends Partial<{
+      calendarInput: Pick<
+        CalendarInputProps,
+        | 'height'
+        | 'width'
+        | 'inputAppearance'
+        | 'popoverAppearance'
+        | 'hoursLabel'
+        | 'minutesLabel'
+        | 'minutesInterval'
+        | 'iconAfter'
+      >
+    }> {}
 }

--- a/packages/calendar-input/src/styles.tsx
+++ b/packages/calendar-input/src/styles.tsx
@@ -1,16 +1,16 @@
 import styled, {DefaultTheme, css} from 'styled-components'
-import {StyledCalendarInputProps, CalendarInputAppearanceType} from './types'
+import {StyledCalendarInputProps, CalendarPopoverAppearanceType} from './types'
 import ReactCalendar from 'react-calendar/dist/entry.nostyle'
 import {TextInput, TextInputAppearanceType} from '@smashing/text-input'
 import {Popover} from '@smashing/popover'
 import {Text, Strong} from '@smashing/typography'
 import {Button} from '@smashing/button'
 
-const getCalendarStyle = (appearance?: CalendarInputAppearanceType) => (_: {
+const getCalendarStyle = (appearance?: CalendarPopoverAppearanceType) => (_: {
   theme: DefaultTheme
 }) => {
   switch (appearance) {
-    case 'outline':
+    case 'dropdown':
       return css`
         .react-calendar__tile.react-calendar__month-view__days__day.react-calendar__tile {
           border-radius: 100%;
@@ -21,8 +21,8 @@ const getCalendarStyle = (appearance?: CalendarInputAppearanceType) => (_: {
   }
 }
 
-const getPopoverStyle = (appearance?: CalendarInputAppearanceType) => {
-  if (appearance === 'outline') {
+const getPopoverStyle = (appearance?: CalendarPopoverAppearanceType) => {
+  if (appearance === 'dropdown') {
     return css`
       box-shadow: none;
       border-top-left-radius: 0;
@@ -88,12 +88,18 @@ export const StyledCalendar = styled(ReactCalendar)<StyledCalendarInputProps>`
   }
 
   ${_ => ({
+    fontFamily: _.theme.fontFamilies.ui,
+    color: _.theme.colors.text.default,
     backgroundColor: _.theme.colors.background.default,
+    button: {
+      fontFamily: 'inherit',
+      color: 'inherit'
+    },
     '.react-calendar__navigation__label': {
+      color: _.theme.colors.text.intense,
       fontWeight: 'bold'
     },
     '.react-calendar__month-view__weekdays, .react-calendar__month-view__days__day--neighboringMonth': {
-      fontFamily: _.theme.fontFamilies.ui,
       color: _.theme.colors.text.muted
     },
     '.react-calendar__tile.react-calendar__month-view__days__day.react-calendar__tile--active, .react-calendar__tile.react-calendar__month-view__days__day.react-calendar__tile--active:focus': {
@@ -113,17 +119,18 @@ export const StyledCalendar = styled(ReactCalendar)<StyledCalendarInputProps>`
   })}
   ${_ => getCalendarStyle(_.appearance)}
 `
-
-export const StyledInput = styled(TextInput)<{
+interface StyledInputProps {
   appearance?: TextInputAppearanceType
-}>`
+}
+export const StyledInput = styled(TextInput)<StyledInputProps>`
   box-sizing: border-box;
   ${_ => getTextInputStyle(_.appearance)}
 `
 
-export const StyledContainer = styled(Popover)<{
-  appearance?: CalendarInputAppearanceType
-}>`
+interface StyledContainerProps {
+  appearance?: CalendarPopoverAppearanceType
+}
+export const StyledContainer = styled(Popover)<StyledContainerProps>`
   ${_ => getPopoverStyle(_.appearance)};
 `
 
@@ -149,6 +156,7 @@ export const ClockElement = styled.div`
   background: transparent;
   text-align: center;
   ${_ => ({
+    color: _.theme.colors.icon.default,
     paddingTop: _.theme.spacing.xxs
   })};
 `
@@ -161,8 +169,6 @@ export const TimePickerHeader = styled(Button)<{visible?: boolean}>`
   align-items: center;
   justify-content: center;
   ${_ => ({
-    paddingTop: _.theme.spacing.xxs,
-    paddingBottom: _.theme.spacing.xxs,
     borderBottom: `1px solid ${_.theme.colors.border.default}`,
     ...(!_.visible && {
       '&:focus': {
@@ -184,6 +190,7 @@ export const ClockButton = styled(Button)<{visible?: boolean}>`
   justify-content: center;
   border-radius: 0;
   ${_ => ({
+    color: _.theme.colors.icon.default,
     paddingTop: _.theme.spacing.xxs,
     paddingBottom: _.theme.spacing.xxs,
     borderTop: `1px solid ${_.theme.colors.border.default}`,

--- a/packages/calendar-input/src/styles.tsx
+++ b/packages/calendar-input/src/styles.tsx
@@ -208,13 +208,18 @@ export const TimeLabel = styled(Text).attrs({
   color: 'muted'
 })`
   display: block;
-  padding: 0 16px;
+  max-width: 144px;
+  margin: 0 auto;
+  padding: 0 ${_ => _.theme.spacing.xxs};
 `
 
 export const TimeButtonsContainer = styled.div`
-  margin: ${_ => `0 ${_.theme.spacing.xs}`};
   display: grid;
   grid-template-columns: repeat(6, 1fr);
+  column-gap: 2px;
+  max-width: 154px;
+  margin: 0 auto;
+  padding: 0 ${_ => _.theme.spacing.xxs};
 `
 
 export const TimePickButton = styled(Text).attrs({

--- a/packages/calendar-input/src/time-picker.tsx
+++ b/packages/calendar-input/src/time-picker.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import * as S from './styles'
-import {ChevronDownIconSm} from './icons'
+import {ChevronDownIcon} from './icons'
 import {TimePickerProps} from './types'
 
 export const TimePicker: React.FC<TimePickerProps> = ({
@@ -14,7 +14,7 @@ export const TimePicker: React.FC<TimePickerProps> = ({
   header,
   close,
   isOpen,
-  collapseIcon = () => <ChevronDownIconSm />
+  collapseIcon = () => <ChevronDownIcon />
 }) => {
   return (
     <S.TimePicker isOpen={isOpen}>

--- a/packages/calendar-input/src/types.ts
+++ b/packages/calendar-input/src/types.ts
@@ -1,13 +1,15 @@
 import {TextInputAppearanceType, TextInputProps} from '@smashing/text-input'
-export type CalendarInputAppearanceType = 'default' | 'outline'
+export type CalendarPopoverAppearanceType = 'card' | 'dropdown'
 
 export type StyledCalendarInputProps = {
-  appearance: CalendarInputAppearanceType
+  appearance: CalendarPopoverAppearanceType
 }
 export type CalendarInputProps = {
-  popoverAppearance: CalendarInputAppearanceType
+  popoverAppearance: CalendarPopoverAppearanceType
   inputAppearance?: TextInputAppearanceType
   onChange?: (date?: Date) => void
+  height?: number
+  width?: number
   value?: Date
   hasTime?: boolean
   hoursLabel?: string
@@ -16,8 +18,7 @@ export type CalendarInputProps = {
   clockIcon?: JSX.Element
   nextIcon?: JSX.Element
   prevIcon?: JSX.Element
-  expandIcon?: React.FC
-  collapseIcon?: React.FC
+  iconAfter?: React.FC<{toggle: () => void; isShown: boolean}>
 }
 
 export type TimePickerProps = {
@@ -38,7 +39,7 @@ export type DateInputProps = Pick<
   CalendarInputProps,
   'onChange' | 'value' | 'hasTime'
 > &
-  Pick<TextInputProps, 'appearance' | 'width'> & {
+  Pick<TextInputProps, 'appearance' | 'width' | 'height'> & {
     getRef: (ref: HTMLElement | null) => void
     onClick: () => void
     openCalendar: () => void
@@ -48,6 +49,5 @@ export type DateInputProps = Pick<
       minutes?: number
     }
     isExpanded?: boolean
-    expandIcon?: React.FC
-    collapseIcon?: React.FC
+    iconAfter?: React.FC<{toggle: () => void; isShown: boolean}>
   }

--- a/packages/text-input/src/styled.tsx
+++ b/packages/text-input/src/styled.tsx
@@ -48,13 +48,14 @@ export const TextInput = styled(Text)<InputProps>`
   ${_ => getTextInputStyle(_.appearance)};
 `
 
-export const TextInputAffix = styled(Text)<{
+interface TextInputAffixProps {
   height: number
   isBefore?: boolean
   isClickable?: boolean
   isString?: boolean
   invalid?: boolean
-}>`
+}
+export const TextInputAffix = styled(Text)<TextInputAffixProps>`
   position: absolute;
   top: 0;
   box-sizing: border-box;
@@ -63,12 +64,22 @@ export const TextInputAffix = styled(Text)<{
   color: ${_ =>
     _.invalid ? _.theme.colors.text.danger : _.theme.colors.text.muted};
   ${_ => (_.isBefore ? 'left: 0;' : 'right: 0;')}
-  ${_ => _.isString && `padding: 0 ${_.theme.spacing.sm};`}
+  ${_ => {
+    const height =
+      typeof _.height === 'string' ? parseInt(_.height, 10) : _.height
+    const padding = Math.round(height / 3.2)
+    if (_.isString) {
+      return {padding: `0 ${padding}px`}
+    }
+    return {
+      svg: {padding: `0 ${padding}px`}
+    }
+  }}
 
   svg {
     width: calc(${_ => _.height}px / 2);
     height: ${_ => _.height}px;
-    padding: 0 ${_ => _.theme.spacing.sm};
+    align-self: center;
     ${_ => _.isClickable && 'cursor: pointer;'}
   }
 `

--- a/packages/theme/src/index.tsx
+++ b/packages/theme/src/index.tsx
@@ -117,6 +117,7 @@ declare module 'styled-components' {
   export interface SmashingSpinnerDefaults {}
   export interface SmashingBarChartDefaults {}
   export interface SmashingListDefaults {}
+  export interface SmashingCalendarInputDefaults {}
   export interface SmashingPieChartDefaults {}
   export interface SmashingProgressBarChartDefaults {}
   export interface SmashingSpiderChartDefaults {}
@@ -125,24 +126,25 @@ declare module 'styled-components' {
   export interface SmashingMenuDefaults {}
   export interface SmashingSelectMenuDefaults {}
   export interface SmashingDefaults
-    extends SmashingButtonDefaults,
-      SmashingCheckboxDefaults,
-      SmashingTextInputDefaults,
-      SmashingTextareaDefaults,
-      SmashingAlertDefaults,
+    extends SmashingAlertDefaults,
+      SmashingAvatarDefaults,
       SmashingBarChartDefaults,
-      SmashingListDefaults,
-      SmashingPieChartDefaults,
-      SmashingSpiderChartDefaults,
-      SmashingRadialProgressDefaults,
+      SmashingButtonDefaults,
+      SmashingCalendarInputDefaults,
+      SmashingCheckboxDefaults,
       SmashingFormFieldDefaults,
-      SmashingProgressBarChartDefaults,
-      SmashingSideSheetDefaults,
-      SmashingSpinnerDefaults,
-      SmashingSelectDefaults,
+      SmashingListDefaults,
       SmashingMenuDefaults,
+      SmashingPieChartDefaults,
+      SmashingProgressBarChartDefaults,
+      SmashingRadialProgressDefaults,
+      SmashingSelectDefaults,
       SmashingSelectMenuDefaults,
-      SmashingAvatarDefaults {}
+      SmashingSideSheetDefaults,
+      SmashingSpiderChartDefaults,
+      SmashingSpinnerDefaults,
+      SmashingTextareaDefaults,
+      SmashingTextInputDefaults {}
   export interface DefaultTheme {
     radius: string
     elevation: SmashingThemeElevation

--- a/stories/calendar-input.stories.js
+++ b/stories/calendar-input.stories.js
@@ -6,8 +6,43 @@ import {SmashingThemeProvider} from '@smashing/theme'
 
 const WrappedCalendar = props => {
   const [date, setDate] = React.useState()
-  return <CalendarInput value={date} onChange={setDate} {...props} />
+  return (
+    <>
+      <style>
+        {
+          'html, body {height: 100%; box-sizing: border-box; margin: 0;} body{ padding: 16px;}'
+        }
+      </style>
+      <CalendarInput value={date} onChange={setDate} {...props} />
+    </>
+  )
 }
+
+export const ChevronDownIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+  >
+    <g fill="currentColor">
+      <path d="M17 9.17a1 1 0 0 0-1.41 0L12 12.71 8.46 9.17a1 1 0 0 0-1.41 0 1 1 0 0 0 0 1.42l4.24 4.24a1 1 0 0 0 1.42 0L17 10.59a1 1 0 0 0 0-1.42z"></path>
+    </g>
+  </svg>
+)
+
+export const ChevronUpIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+  >
+    <g fill="currentColor">
+      <path d="M17 13.41l-4.29-4.24a1 1 0 0 0-1.42 0l-4.24 4.24a1 1 0 0 0 0 1.42 1 1 0 0 0 1.41 0L12 11.29l3.54 3.54a1 1 0 0 0 .7.29 1 1 0 0 0 .71-.29 1 1 0 0 0 .05-1.42z"></path>
+    </g>
+  </svg>
+)
 
 addDecorator(withA11y)
 storiesOf('Form|Calendar input', module)
@@ -15,7 +50,7 @@ storiesOf('Form|Calendar input', module)
     <SmashingThemeProvider
       theme={{
         defaults: {
-          calendar: {}
+          calendarInput: {}
         }
       }}
     >
@@ -25,12 +60,39 @@ storiesOf('Form|Calendar input', module)
   .add('appearance:default', () => <WrappedCalendar />)
   .add('appearance:default with time', () => <WrappedCalendar hasTime />)
   .add('appearance:outline', () => (
-    <WrappedCalendar inputAppearance="outline" popoverAppearance="outline" />
+    <WrappedCalendar inputAppearance="outline" popoverAppearance="dropdown" />
   ))
   .add('appearance:outline with time', () => (
     <WrappedCalendar
       inputAppearance="outline"
       hasTime
-      popoverAppearance="outline"
+      popoverAppearance="accordion"
     />
+  ))
+  .add('popoverAppearance:dropdown', () => (
+    <WrappedCalendar inputAppearance="outline" popoverAppearance="dropdown" />
+  ))
+  .add('height', () => (
+    <>
+      <WrappedCalendar hasTime width={180} height={24} />
+      <br />
+      <WrappedCalendar hasTime />
+      <br />
+      <WrappedCalendar hasTime width={230} height={40} />
+      <br />
+      <WrappedCalendar hasTime width={270} height={48} />
+      <br />
+    </>
+  ))
+  .add('custom icon', () => (
+    <>
+      <WrappedCalendar hasTime iconAfter={ChevronDownIcon} />
+      <br />
+      <WrappedCalendar
+        hasTime
+        iconAfter={({isShown}) =>
+          isShown ? <ChevronUpIcon /> : <ChevronDownIcon />
+        }
+      />
+    </>
   ))


### PR DESCRIPTION
- replaced `expandIcon` and `collapseIcon` with `iconAfter` which gets `isShown` as argument 
```tsx
iconAfter={({isShown}) => isShown ? <Up/> : <Down/>}
```
- apply theme colors to all text
- changed icon for active input to highlighted calendar 
- added support for `height` prop
- fixed defaults

![](https://i.imgur.com/BXlHY5z.gif)