### PR TITLE
fix: add popover props to control group

### DIFF
--- a/packages/control-group/src/index.tsx
+++ b/packages/control-group/src/index.tsx
@@ -128,7 +128,8 @@ const ControlGroupFC: React.FC<ControlGroupProps> = props => {
     textAlign,
     disabled,
     invalid,
-    visibleCount
+    visibleCount,
+    popoverProps
   } = props
 
   const [controlsNumber, setControlsNumber] = React.useState(0)
@@ -224,6 +225,7 @@ const ControlGroupFC: React.FC<ControlGroupProps> = props => {
               isSelectable={false}
               disabled={disabled}
               invalid={invalid}
+              popoverProps={popoverProps}
             />
             <MoreButton
               key="more-button"

--- a/packages/control-group/src/types.ts
+++ b/packages/control-group/src/types.ts
@@ -1,6 +1,7 @@
 import {ButtonAppearanceType} from '@smashing/button'
 import {RadioAppearanceType} from '@smashing/radio'
 import {CheckboxAppearanceType} from '@smashing/checkbox'
+import {PopoverProps} from '@smashing/popover'
 
 export type Layout = 'default' | 'equal' | 'full'
 export type TextAlign = 'left' | 'center' | 'right'
@@ -41,6 +42,7 @@ export interface ControlGroupProps
   items: ControlItemProps[]
   layout?: Layout
   visibleCount?: number
+  popoverProps?: Partial<PopoverProps>
 }
 
 export interface ButtonProps {

--- a/stories/control-group.stories.js
+++ b/stories/control-group.stories.js
@@ -274,7 +274,11 @@ storiesOf('Form|ControlGroup/controlAppearance:outline', module)
         value={value}
         items={items}
         layout="equal"
+        visibleCount={3}
         controlAppearance="outline"
+        popoverProps={{
+          height: 100
+        }}
       />
     )
   })


### PR DESCRIPTION
Added `popover props` to manage `select-menu`'s popover dimensions 