### PR TITLE
fix: text-input affix alignment

### DIFF
--- a/packages/text-input/src/styled.tsx
+++ b/packages/text-input/src/styled.tsx
@@ -59,8 +59,9 @@ export const TextInputAffix = styled(Text)<TextInputAffixProps>`
   position: absolute;
   top: 0;
   box-sizing: border-box;
-  height: ${_ => _.height}px;
-  line-height: ${_ => _.height}px;
+  height: 100%;
+  display: flex;
+  align-items: center;
   color: ${_ =>
     _.invalid ? _.theme.colors.text.danger : _.theme.colors.text.muted};
   ${_ => (_.isBefore ? 'left: 0;' : 'right: 0;')}


### PR DESCRIPTION
When input hasn't set height, affix isn't properly align
![image](https://user-images.githubusercontent.com/12514404/75233673-80d17b80-57b9-11ea-9390-1d00d524c70d.png)
